### PR TITLE
Old Style Brace Syntax fixen

### DIFF
--- a/catalog/upload_usmarc.php
+++ b/catalog/upload_usmarc.php
@@ -52,13 +52,13 @@ foreach($records as $record) {
   
   $j=0;
   foreach(explode($fieldterminator,substr($record,$start)) as $field) {
-    if ($codes[$j]{0} == '0' and $codes[$j]{1} == '0') {
+    if ($codes[$j][0] == '0' and $codes[$j][1] == '0') {
       $j++;
       continue;  // We don't support control fields yet
     }
     // Skip three characters to drop indicators and the first delimiter.
     foreach(explode($delimiter,substr($field, 3)) as $subfield) {
-      $ident = $subfield{0};
+      $ident = $subfield[0];
       $data=substr($subfield,1);
 
       if (in_array($codes[$j].$ident, $exclude)) {

--- a/circ/offline.php
+++ b/circ/offline.php
@@ -26,10 +26,10 @@
       $command = trim(array_shift($lines));
       if($command == '')
         continue;
-      if($command{0} != '%')
+      if($command[0] != '%')
         return array($loc->getText("Bad upload file: Expected a command code, but didn't get one"));
       $args = array();
-      while (isset($lines[0]) and $lines[0]{0} != '%')
+      while (isset($lines[0]) and $lines[0][0] != '%')
         $args[] = trim(array_shift($lines));
       switch($command){
       case '%CHECKOUT%':

--- a/classes/Lay.php
+++ b/classes/Lay.php
@@ -722,7 +722,7 @@ class Lay {
       switch ($type) {
       case 'x-length':
       case 'y-length':
-        list($len, $err) = $this->lengthToPoints($p[$name], $type{0});
+        list($len, $err) = $this->lengthToPoints($p[$name], $type[0]);
         $p[$name] = $len;
         break;
       case 'x-align':
@@ -732,8 +732,8 @@ class Lay {
         $atypes['y'] = array('top', 'bottom');
         $atypes['both'] = array('center', 'justify', 'strict-justify', 'baseline');
         if (!in_array($p[$name], $atypes['both'])
-            and !in_array($p[$name], $atypes[$type{0}])) {
-          $err = 'invalid '.$type{0}.' alignment type';
+            and !in_array($p[$name], $atypes[$type[0]])) {
+          $err = 'invalid '.$type[0] .' alignment type';
         }
         break;
       case 'boolean':

--- a/classes/PDF.php
+++ b/classes/PDF.php
@@ -151,7 +151,7 @@ class PDF {
     $w=0;
     $l=strlen($s);
     for($i=0;$i<$l;$i++) {
-      $w+=$cw[$s{$i}];
+      $w+=$cw[$s[$i]];
     }
     # array(x-min, y-min, x-max, y-max) -- LOWER-LEFT ORIGIN
     $bbox = $this->currentFont['bbox'];
@@ -581,13 +581,13 @@ class PDF {
       $compressed=(substr($file,-2)=='.z');
       if(!$compressed && isset($info['length2']))
       {
-        $header=(ord($font{0})==128);
+        $header=(ord($font[0])==128);
         if($header)
         {
           //Strip first binary header
           $font=substr($font,6);
         }
-        if($header && ord($font{$info['length1']})==128)
+        if($header && ord($font[$info['length1']])==128)
         {
           //Strip second binary header
           $font=substr($font,0,$info['length1']).substr($font,$info['length1']+6);

--- a/classes/RptParser.php
+++ b/classes/RptParser.php
@@ -125,10 +125,10 @@ class RptParser {
     # NOTE: Lines longer than 4096 bytes will mess things up.
     while ($line = fgets($this->fd, 4096)) {
       $this->line++;
-      if ($line == "\n" or $line == "\r\n" or $line == "\r" or $line{0} == '#') {
+      if ($line == "\n" or $line == "\r\n" or $line == "\r" or $line[0] == '#') {
         continue;
       }
-      if ($line{0} == '.') {
+      if ($line[0] == '.') {
         $this->_tokens = $this->getCmdTokens(trim(substr($line, 1)));
       } else {
         $this->_tokens = $this->getSqlTokens(trim($line));
@@ -150,22 +150,22 @@ class RptParser {
                   'else', 'subselect', 'end', 'order_by_expr');
     $list = array();
     while (!empty($str)) {
-      if ($str{0} == ' ' or $str{0} == "\t") {
+      if ($str[0] == ' ' or $str[0] == "\t") {
         $str = substr($str, 1);
         continue;
       }
-      if (ctype_alnum($str{0})) {
+      if (ctype_alnum($str[0])) {
         $w = '';
-        while (!empty($str) and (ctype_alnum($str{0}) or $str{0} == '_')) {
-          $w .= $str{0};
+        while (!empty($str) and (ctype_alnum($str[0]) or $str[0] == '_')) {
+          $w .= $str[0];
           $str = substr($str, 1);
         }
         array_push($list, array('WORD', $w));
-      } else if ($str{0} == '"' or $str{0} == '\'') {
+      } else if ($str[0] == '"' or $str[0] == '\'') {
         list($w, $str) = $this->getQuoted($str);
         array_push($list, array('WORD', $w));
       } else {
-        array_push($list, array($str{0}));
+        array_push($list, array($str[0]));
         $str = substr($str, 1);
       }
     }
@@ -178,19 +178,19 @@ class RptParser {
     if (empty($str)) {
       Fatal::internalError('getQuoted() called with empty $str');
     }
-    $q = $str{0};
+    $q = $str[0];
     $w = '';
     for ($n=1; $n < strlen($str); $n++) {
-      if ($str{$n} == $q) {
+      if ($str[$n] == $q) {
         break;
       }
-      if ($str{$n} == '\\') {
+      if ($str[$n] == '\\') {
         $n++;
         if ($n >= strlen($str)) {
           break;
         }
       }
-      $w .= $str{$n};
+      $w .= $str[$n];
     }
     return array($w, substr($str, $n+1));
   }
@@ -222,8 +222,8 @@ class RptParser {
           array_push($list, array('SQLCODE', $sql));
           $sql = '';
         }
-        if (array_key_exists($ref{0}, $conversions)) {
-          $conv = $conversions[$ref{0}];
+        if (array_key_exists($ref[0], $conversions)) {
+          $conv = $conversions[$ref[0]];
           $ref = substr($ref, 1);
         } else {
           $conv = '%Q';

--- a/classes/Search.php
+++ b/classes/Search.php
@@ -74,26 +74,26 @@ class Search {
     for($i=0; $i<strlen($str); $i++) {
       if ($q) {
         if ($bs) {
-          $s .= $str{$i};
+          $s .= $str[$i];
           $bs = false;
-        } else if ($str{$i} == "\\") {
+        } else if ($str[$i] == "\\") {
           $bs = true;
-        } else if ($str{$i} == "\"") {
+        } else if ($str[$i] == "\"") {
           $q = false;
         } else {
-          $s .= $str{$i};
+          $s .= $str[$i];
         }
       } else {
-        if ($str{$i} == "\"") {
+        if ($str[$i] == "\"") {
           $q = true;
-        } else if ($str{$i} == " " or $str{$i} == "\t"
-                   or $str{$i} == "\r" or $str{$i} == "\n") {
+        } else if ($str[$i] == " " or $str[$i] == "\t"
+                   or $str[$i] == "\r" or $str[$i] == "\n") {
           if (strlen($s)) {
             $elements[] = $s;
             $s = "";
           }
         } else {
-          $s .= $str{$i};
+          $s .= $str[$i];
         }
       }
     }

--- a/font/makefont/makefont-new.php
+++ b/font/makefont/makefont-new.php
@@ -18,12 +18,12 @@
 $core = false;
 $args = $_SERVER['argv'];
 $prog_name = array_shift($args);
-while (isset($args[0]) and strlen($args[0]>1) and $args[0]{0} == '-') {
+while (isset($args[0]) and strlen($args[0]>1) and $args[0][0] == '-') {
 	$arg = array_shift($args);
-	if ($arg{1} == '-') {
+	if ($arg[1] == '-') {
 		break;
 	}
-	switch ($arg{1}) {
+	switch ($arg[1]) {
 	case 'c':
 		$core = true;
 		break;
@@ -88,7 +88,7 @@ function ReadMap($enc)
 	$cc2gn=array();
 	foreach($a as $l)
 	{
-		if($l{0}=='!')
+		if($l[0] =='!')
 		{
 			$e=preg_split('/[ \\t]+/',rtrim($l));
 			$cc=hexdec(substr($e[0],1));
@@ -436,7 +436,7 @@ function MakeFont($fontfile,$afmfile,$enc='cp1252',$patch=array(),$type='TrueTyp
 		if($type=='Type1')
 		{
 			//Find first two sections and discard third one
-			$header=(ord($file{0})==128);
+			$header=(ord($file[0])==128);
 			if($header)
 			{
 				//Strip first binary header
@@ -446,7 +446,7 @@ function MakeFont($fontfile,$afmfile,$enc='cp1252',$patch=array(),$type='TrueTyp
 			if(!$pos)
 				die('<B>Error:</B> font file does not seem to be valid Type1');
 			$size1=$pos+6;
-			if($header and ord($file{$size1})==128)
+			if($header and ord($file[$size1])==128)
 			{
 				//Strip second binary header
 				$file=substr($file,0,$size1).substr($file,$size1+6);

--- a/font/makefont/makefont.php
+++ b/font/makefont/makefont.php
@@ -15,7 +15,7 @@ function ReadMap($enc)
 	$cc2gn=array();
 	foreach($a as $l)
 	{
-		if($l{0}=='!')
+		if($l[0] =='!')
 		{
 			$e=preg_split('/[ \\t]+/',rtrim($l));
 			$cc=hexdec(substr($e[0],1));
@@ -363,7 +363,7 @@ function MakeFont($fontfile,$afmfile,$enc='cp1252',$patch=array(),$type='TrueTyp
 		if($type=='Type1')
 		{
 			//Find first two sections and discard third one
-			$header=(ord($file{0})==128);
+			$header=(ord($file[0])==128);
 			if($header)
 			{
 				//Strip first binary header
@@ -373,7 +373,7 @@ function MakeFont($fontfile,$afmfile,$enc='cp1252',$patch=array(),$type='TrueTyp
 			if(!$pos)
 				die('<B>Error:</B> font file does not seem to be valid Type1');
 			$size1=$pos+6;
-			if($header and ord($file{$size1})==128)
+			if($header and ord($file[$size1])==128)
 			{
 				//Strip second binary header
 				$file=substr($file,0,$size1).substr($file,$size1+6);


### PR DESCRIPTION
Fixed alle PhpCurlyBraceAccessSyntaxUsageInspection errors, denn"Curly brace access syntax is deprecated since PHP 7.4".
Siehe Issue: #1 

Auto fix von PHPStorm 2022.2.1 - ich sehe keine Fehler dabei, aber man sollte das mal erwähnen...